### PR TITLE
support for switching in and out of lax mode checking from emacs

### DIFF
--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -869,7 +869,7 @@ multiple arguments as one string will not work: you should use
 
 (defun fstar-subp--column-number-at-pos (pos)
   "Return column number at POS."
-  (save-excursion (goto-char pos) (current-column)))
+  (save-excursion (goto-char pos) (- (point) (point-at-bol))))
 
 (defun fstar-subp--header (pos lax)
   "Prepare a header for a region starting at POS.

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -475,10 +475,20 @@ If MUST-FIND-TYPE is nil, the :type part is not necessary."
   "Face used to highlight pending sections of the buffer."
   :group 'fstar)
 
+(defface fstar-subp-overlay-pending-lax-face
+  '((t :inherit fstar-subp-overlay-pending-face))
+  "Face used to highlight pending lax sections of the buffer."
+  :group 'fstar)
+
 (defface fstar-subp-overlay-busy-face
   '((((background light)) :background "mistyrose")
     (((background dark))  :background "mediumorchid"))
   "Face used to highlight busy sections of the buffer."
+  :group 'fstar)
+
+(defface fstar-subp-overlay-busy-lax-face
+  '((t :inherit fstar-subp-overlay-busy-face))
+  "Face used to highlight busy lax sections of the buffer."
   :group 'fstar)
 
 (defface fstar-subp-overlay-processed-face
@@ -487,7 +497,7 @@ If MUST-FIND-TYPE is nil, the :type part is not necessary."
   "Face used to highlight processed sections of the buffer."
   :group 'fstar)
 
-(defface fstar-subp-overlay-processedlax-face
+(defface fstar-subp-overlay-processed-lax-face
   '((((background light)) :background "#E5E7E9")
     (((background dark))  :background "lightgrey"))
   "Face used to highlight processed lax-checked sections of the buffer."
@@ -942,11 +952,9 @@ Modifications are only allowed if it is safe to retract up to the beginning of t
 (defun fstar-subp-set-status (overlay status)
   "Set status of OVERLAY to STATUS."
   (fstar-assert (memq status fstar-subp-statuses))
-  (let ((inhibit-read-only t)
-        (face-name (if (and (eq (overlay-get overlay 'fstar-subp--lax) 1)
-			    (string= (symbol-name status) "processed")) 
-		       "fstar-subp-overlay-processedlax-face"
-		     (concat "fstar-subp-overlay-" (symbol-name status) "-face"))))
+  (let* ((inhibit-read-only t)
+         (face-name (format "fstar-subp-overlay-%s-%sface" (symbol-name status)
+                            (if (overlay-get overlay 'fstar-subp--lax) "lax-" ""))))
     (overlay-put overlay 'fstar-subp-status status)
     (overlay-put overlay 'priority -1) ;;FIXME this is not an allowed value
     (overlay-put overlay 'face (intern face-name))

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -680,7 +680,7 @@ With prefix argument ARG, kill all F* subprocesses."
 
 (defun fstar-subp-cleanup-issue (issue)
   "Make sure that ISSUE mentions a file name."
-  (when (string= (fstar-issue-filename issue) "<input>")
+  (when (member (fstar-issue-filename issue) '("unknown" "<input>"))
     (setf (fstar-issue-filename issue) (buffer-file-name))) ;; FIXME ensure we have a file name?
   issue)
 

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -486,6 +486,12 @@ If MUST-FIND-TYPE is nil, the :type part is not necessary."
   "Face used to highlight processed sections of the buffer."
   :group 'fstar)
 
+(defface fstar-subp-overlay-processedlax-face
+  '((((background light)) :background "#E5E7E9")
+    (((background dark))  :background "lightgrey"))
+  "Face used to highlight processed lax-checked sections of the buffer."
+  :group 'fstar)
+
 (defface fstar-subp-overlay-issue-face
   '((t :underline (:color "red" :style wave)))
   "Face used to highlight processed sections of the buffer."
@@ -945,7 +951,10 @@ Modifications are only allowed if it is safe to retract up to the beginning of t
   "Set status of OVERLAY to STATUS."
   (fstar-assert (memq status fstar-subp-statuses))
   (let ((inhibit-read-only t)
-        (face-name (concat "fstar-subp-overlay-" (symbol-name status) "-face")))
+        (face-name (if (and (eq (overlay-get overlay 'is-lax) 1)
+			    (string= (symbol-name status) "processed")) 
+		       "fstar-subp-overlay-processedlax-face"
+		     (concat "fstar-subp-overlay-" (symbol-name status) "-face"))))
     (overlay-put overlay 'fstar-subp-status status)
     (overlay-put overlay 'priority -1) ;;FIXME this is not an allowed value
     (overlay-put overlay 'face (intern face-name))

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -951,7 +951,7 @@ Modifications are only allowed if it is safe to retract up to the beginning of t
   "Set status of OVERLAY to STATUS."
   (fstar-assert (memq status fstar-subp-statuses))
   (let ((inhibit-read-only t)
-        (face-name (if (and (eq (overlay-get overlay 'is-lax) 1)
+        (face-name (if (and (eq (overlay-get overlay 'fstar-subp--lax) 1)
 			    (string= (symbol-name status) "processed")) 
 		       "fstar-subp-overlay-processedlax-face"
 		     (concat "fstar-subp-overlay-" (symbol-name status) "-face"))))
@@ -967,7 +967,7 @@ Modifications are only allowed if it is safe to retract up to the beginning of t
   (fstar-subp-start)
   (fstar-subp-set-status overlay 'busy)
   (setq fstar-subp--busy-now overlay)
-  (fstar-subp-send-region (overlay-start overlay) (overlay-end overlay) (overlay-get overlay 'is-lax)))
+  (fstar-subp-send-region (overlay-start overlay) (overlay-end overlay) (overlay-get overlay 'fstar-subp--lax)))
 
 (defun fstar-subp-process-queue ()
   "Process the next pending overlay, if any."
@@ -1005,7 +1005,7 @@ If NO-ERROR is set, do not report an error if the region is empty."
           (user-error "Nothing more to process!"))
       (let ((overlay (make-overlay beg end (current-buffer) nil nil)))
         (fstar-subp-set-status overlay 'pending)
-	(overlay-put overlay 'is-lax lax)
+        (overlay-put overlay 'fstar-subp--lax lax)
         (fstar-subp-process-queue)))))
 
 (defcustom fstar-subp-block-sep "\\(\\'\\|\\s-*\\(\n\\s-*\\)\\{3,\\}\\)" ;; FIXME add magic comment

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -874,8 +874,8 @@ multiple arguments as one string will not work: you should use
 (defun fstar-subp--header (pos lax)
   "Prepare a header for a region starting at POS.
 With non-nil LAX, the region is to be processed in lax mode."
-  (format "#push %d %d%s\n"
-          (line-number-at-pos pos)
+  (format "#push %d %d%s"
+          (1- (line-number-at-pos pos))
           (fstar-subp--column-number-at-pos pos)
           (if lax " #lax" "")))
 


### PR DESCRIPTION
Hi Clément:

Could you please review this change to support switching in and out of lax mode directly from emacs, on a per fragment basis.

If the first line (header) of the fragment is `#push` then the code is verified as before, but if it is `#push #lax`, then F* uses lax mode for the fragment. Current key bindings send the header as `#push` as is, and a new key binding sends the lax mode header. This way, we can switch in and out of lax mode on a per fragment basis without using `#set-options` in the buffer itself, as it can become tedious to maintain other options such as fuels, timeouts, etc. alongside.

The change basically sets an attribute on the overlay, set as per the key binding the programmer uses, and then reads this attribute to set the appropriate header when sending the fragment to F*. The change is currently a bit unsatisfying as I had to copy a function, whereas I would have liked to pass an argument for lax mode. I could not make it work with the argument, and my suspicion is that it was because of handling of the optional arguments. There is a comment in the file `AR:...` for this.

Thanks!