### PR TITLE
Add syntax highlighting for [class] and [instance]

### DIFF
--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -848,7 +848,7 @@ allows composition in code comments."
   '("open" "module" "include" "friend"
     "let" "let rec" "val" "and"
     "exception" "effect" "new_effect" "sub_effect" "new_effect_for_free"
-    "kind" "type"))
+    "kind" "type" "class" "instance"))
 
 (defconst fstar-syntax-fsdoc-keywords
   '("@author" "@summary"))
@@ -1140,7 +1140,7 @@ leads to the binder's start."
       (,(concat "\\_<\\(let\\(?: +rec\\)?\\|and\\)\\_>\\(\\(?: +" id "\\( *, *" id "\\)*\\)?\\)")
        (1 'fstar-structure-face)
        (2 'font-lock-function-name-face))
-      (,(concat "\\_<\\(type\\|kind\\)\\( +" id "\\)")
+      (,(concat "\\_<\\(type\\|kind\\|class\\|instance\\)\\( +" id "\\)")
        (1 'fstar-structure-face)
        (2 'font-lock-function-name-face))
       (,(concat "\\_<\\(val\\) +\\(" id "\\) *:")


### PR DESCRIPTION
Adds syntax highlighting for the `class` and `instance` keywords. It also makes them act like `type` in that the identifier right after them is highlighted.

![screenshot from 2019-01-23 15-40-49](https://user-images.githubusercontent.com/5683582/51635649-4b5abe80-1f25-11e9-8e5e-d065b605e06c.png)
