### PR TITLE
Being able to jump to definition even if F* not loaded in current buffer

### DIFF
--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -4210,12 +4210,13 @@ DISPLAY-ACTION indicates how: nil means in the current window;
   "Jump to definition of identifier at POS, if any.
 DISP should be nil (display in same window) or
 `window' (display in a side window)."
-  (let ((buf (fstar-subp--ensure-available-free-anywhere #'user-error)))
+  (let ((buf (fstar-subp--ensure-available-free-anywhere #'user-error))
+	(query (fstar-subp--positional-lookup-query pos '(defined-at)))
+	(continuation (fstar-subp--lookup-wrapper pos (apply-partially
+						       #'fstar--jump-to-definition-continuation
+						       disp))))
     (with-current-buffer buf
-      (fstar-subp--query (fstar-subp--positional-lookup-query pos '(defined-at))
-    			 (fstar-subp--lookup-wrapper pos (apply-partially
-    							  #'fstar--jump-to-definition-continuation
-    							  disp))))))
+      (fstar-subp--query query continuation))))
 
 (defun fstar-jump-to-definition ()
   "Jump to definition of identifier at point, if any."

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -706,6 +706,9 @@ enable all experimental features."
 (defvar-local fstar--features nil
   "List of available F* features.")
 
+(defvar-local fstar--parent-buffer nil
+  "The buffer that opened the current buffer, if it exists.")
+
 (defun fstar--query-vernum (executable)
   "Ask F* EXECUTABLE for its version number."
   (let ((fname buffer-file-name))

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -2347,9 +2347,9 @@ FEATURE, if specified."
   (when feature
     (fstar--has-feature feature error-fn)))
 
-(defun fstar-subp--find-any-free-process (error-fn)
-  "Return a free fstar process if available in some buffer.
-Raise an error with ERROR-FN if a free F* process isn't available anywhere."
+(defun fstar-subp--find-any-live-process (error-fn)
+  "Return a live fstar process if available in some buffer.
+Raise an error with ERROR-FN if a live F* process isn't available anywhere."
   (cl-loop for buf in `(,(current-buffer) ,fstar--parent-buffer ,@(buffer-list))
 	   for proc = (and buf
 			   (eq (buffer-local-value 'major-mode buf) 'fstar-mode)
@@ -4209,7 +4209,7 @@ DISPLAY-ACTION indicates how: nil means in the current window;
 DISP should be nil (display in same window) or
 `window' (display in a side window)."
   (let ((cur-buf (current-buffer))
-	(buf (fstar-subp--find-any-free-process #'user-error))
+	(buf (fstar-subp--find-any-live-process #'user-error))
 	(query (fstar-subp--positional-lookup-query pos '(defined-at))))
     (with-current-buffer buf
       (fstar-subp--query query

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -423,7 +423,7 @@ If END is nil, pulse the entire line containing BEG."
 (defvar-local fstar--parent-buffer nil
   "The buffer that opened the current buffer, if it exists.
 This is relevant when (for example) a user jumps to the current
-buffer using a 'jump to definition' command. If it is set, then
+buffer using a 'jump to definition' command.  If it is set, then
 this buffer may be used to run F* queries if an F* process isn't
 started in the current buffer.")
 

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -4194,26 +4194,28 @@ the search buffer."
 
 ;;; ;; ;; Jump to definition
 
-(defun fstar--jump-to-definition-continuation (display-action info)
+(defun fstar--jump-to-definition-continuation (cur-buf display-action info)
   "Jump to position in INFO.
 DISPLAY-ACTION indicates how: nil means in the current window;
 `window' means in a side window."
   (-if-let* ((def-loc (and (fstar-lookup-result-p info)
 			   (fstar-lookup-result-def-loc info))))
-      (fstar--navigate-to def-loc display-action)
+      (with-current-buffer cur-buf
+	(fstar--navigate-to def-loc display-action))
     (message "No definition found")))
 
 (defun fstar-jump-to-definition-1 (pos disp)
   "Jump to definition of identifier at POS, if any.
 DISP should be nil (display in same window) or
 `window' (display in a side window)."
-  (let ((buf (fstar-subp--find-any-free-process #'user-error))
+  (let ((cur-buf (current-buffer))
+	(buf (fstar-subp--find-any-free-process #'user-error))
 	(query (fstar-subp--positional-lookup-query pos '(defined-at))))
     (with-current-buffer buf
       (fstar-subp--query query
 			 (fstar-subp--lookup-wrapper (point) (apply-partially
 							      #'fstar--jump-to-definition-continuation
-							      disp))))))
+							      cur-buf disp))))))
 
 (defun fstar-jump-to-definition ()
   "Jump to definition of identifier at point, if any."

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -420,6 +420,9 @@ If END is nil, pulse the entire line containing BEG."
     (when (fboundp 'pulse-momentary-highlight-one-line)
       (pulse-momentary-highlight-one-line beg))))
 
+(defvar-local fstar--parent-buffer nil
+  "The buffer that opened the current buffer, if it exists.")
+
 (defun fstar--navigate-to-1 (location display-action switch)
   "Navigate to LOCATION.
 DISPLAY-ACTION determines where the resulting buffer is
@@ -707,9 +710,6 @@ enable all experimental features."
 
 (defvar-local fstar--features nil
   "List of available F* features.")
-
-(defvar-local fstar--parent-buffer nil
-  "The buffer that opened the current buffer, if it exists.")
 
 (defun fstar--query-vernum (executable)
   "Ask F* EXECUTABLE for its version number."

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -438,6 +438,7 @@ window become current and selected."
     (if (not (file-exists-p fname))
         (message "File not found: %S" fname)
       (-when-let* ((buf (find-file-noselect fname))
+		   (cur-buf (current-buffer))
                    (win (if (not switch)
                             (display-buffer buf action)
                           (when (eq (pop-to-buffer buf action)
@@ -446,6 +447,7 @@ window become current and selected."
         (with-selected-window win
           (with-current-buffer buf ;; FIXME check this
             (push-mark (point) t) ;; Save default position in mark ring
+	    (setq fstar--parent-buffer cur-buf)
             (fstar--goto-line-col (or line 1) col)
             (recenter)
             (when line

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -2343,18 +2343,22 @@ FEATURE, if specified."
 Raise an error with ERROR-FN if a free F* process isn't available anywhere."
   (let ((result nil))
     (catch 'here
-      (if (fstar-subp-live-p)
-	  (throw 'here (current-buffer)))
+      (if (fstar-subp-live-p fstar-subp--process)
+	(progn
+	  (setq result (current-buffer))
+	  (throw 'here t)))
       (let ((buflist (buffer-list)))
 	(dolist (buf (buffer-list))
 	  (if (and
 	       (eq (buffer-local-value 'major-mode buf)
 		   'fstar-mode)
 	       (fstar-subp-live-p (buffer-local-value 'fstar-subp--process buf)))
-	      (throw 'here buf)))))
+	      (progn
+		(setq result buf)
+		(throw 'here t))))))
     (if result result
-      (funcall error-fn "Unable to find a free F* process. Either
-      F* is not started, or all buffers are processing."))))
+      (funcall error-fn "Unable to find a free F* process. Either \
+F* is not started, or all buffers are processing."))))
 
 (defun fstar-subp--serialize-query (query id)
   "Serialize QUERY with ID to JSON."

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -445,7 +445,7 @@ window become current and selected."
     (if (not (file-exists-p fname))
         (message "File not found: %S" fname)
       (-when-let* ((buf (find-file-noselect fname))
-		   (cur-buf (or fstar--parent-buffer (current-buffer)))
+		   (parent-buf (or fstar--parent-buffer (current-buffer)))
                    (win (if (not switch)
                             (display-buffer buf action)
                           (when (eq (pop-to-buffer buf action)
@@ -454,7 +454,7 @@ window become current and selected."
         (with-selected-window win
           (with-current-buffer buf ;; FIXME check this
             (push-mark (point) t) ;; Save default position in mark ring
-	    (setq fstar--parent-buffer cur-buf)
+	    (setq fstar--parent-buffer parent-buf)
             (fstar--goto-line-col (or line 1) col)
             (recenter)
             (when line

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -2350,7 +2350,7 @@ Raise an error with ERROR-FN if a free F* process isn't available anywhere."
 	(progn
 	  (setq result (current-buffer))
 	  (throw 'here t)))
-      (let ((buflist (buffer-list)))
+      (let ((buflist (cons (or fstar--parent-buffer (current-buffer)) (buffer-list))))
 	(dolist (buf (buffer-list))
 	  (if (and
 	       (eq (buffer-local-value 'major-mode buf)

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -2343,6 +2343,8 @@ FEATURE, if specified."
 Raise an error with ERROR-FN if a free F* process isn't available anywhere."
   (let ((result nil))
     (catch 'here
+      (if (fstar-subp-live-p)
+	  (throw 'here (current-buffer)))
       (let ((buflist (buffer-list)))
 	(dolist (buf (buffer-list))
 	  (if (and

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -3689,7 +3689,7 @@ Must be called with syntax table `fstar--fqn-at-point-syntax-table'"
                ("symbol" . ,(or (fstar--fqn-at-point pos) ""))
                ("requested-info" . ,fields)
                ("location" .
-                (("filename" . "<input>")
+                (("filename" . ,(buffer-file-name))
                  ("line" . ,(line-number-at-pos pos))
                  ("column" . ,(fstar-subp--column-number-at-pos pos))))))
     (if (fstar--has-feature 'info-includes-symbol)

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -445,7 +445,7 @@ window become current and selected."
     (if (not (file-exists-p fname))
         (message "File not found: %S" fname)
       (-when-let* ((buf (find-file-noselect fname))
-		   (cur-buf (current-buffer))
+		   (cur-buf (or fstar--parent-buffer (current-buffer)))
                    (win (if (not switch)
                             (display-buffer buf action)
                           (when (eq (pop-to-buffer buf action)

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -421,7 +421,11 @@ If END is nil, pulse the entire line containing BEG."
       (pulse-momentary-highlight-one-line beg))))
 
 (defvar-local fstar--parent-buffer nil
-  "The buffer that opened the current buffer, if it exists.")
+  "The buffer that opened the current buffer, if it exists.
+This is relevant when (for example) a user jumps to the current
+buffer using a 'jump to definition' command. If it is set, then
+this buffer may be used to run F* queries if an F* process isn't
+started in the current buffer.")
 
 (defun fstar--navigate-to-1 (location display-action switch)
   "Navigate to LOCATION.

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -2338,6 +2338,22 @@ FEATURE, if specified."
   (when feature
     (fstar--has-feature feature error-fn)))
 
+(defun fstar-subp--ensure-available-free-anywhere (error-fn)
+  "Return a free fstar process if available in some buffer.
+Raise an error with ERROR-FN if a free F* process isn't available anywhere."
+  (let ((result nil))
+    (catch 'here
+      (let ((buflist (buffer-list)))
+	(dolist (buf (buffer-list))
+	  (if (and
+	       (eq (buffer-local-value 'major-mode buf)
+		   'fstar-mode)
+	       (fstar-subp-live-p (buffer-local-value 'fstar-subp--process buf)))
+	      (throw 'here buf)))))
+    (if result result
+      (funcall error-fn "Unable to find a free F* process. Either
+      F* is not started, or all buffers are processing."))))
+
 (defun fstar-subp--serialize-query (query id)
   "Serialize QUERY with ID to JSON."
   (let ((json-encoding-pretty-print nil)

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -2357,8 +2357,7 @@ Raise an error with ERROR-FN if a free F* process isn't available anywhere."
 		(setq result buf)
 		(throw 'here t))))))
     (if result result
-      (funcall error-fn "Unable to find a free F* process. Either \
-F* is not started, or all buffers are processing."))))
+      (fstar-subp--ensure-available error-fn))))
 
 (defun fstar-subp--serialize-query (query id)
   "Serialize QUERY with ID to JSON."

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -2353,7 +2353,7 @@ Raise an error with ERROR-FN if a free F* process isn't available anywhere."
 	  (setq result (current-buffer))
 	  (throw 'here t)))
       (let ((buflist (cons (or fstar--parent-buffer (current-buffer)) (buffer-list))))
-	(dolist (buf (buffer-list))
+	(dolist (buf buflist)
 	  (if (and
 	       (eq (buffer-local-value 'major-mode buf)
 		   'fstar-mode)

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -5256,6 +5256,7 @@ Could it be a typo in `fstar-subp-prover-args' or \
         (set-process-coding-system proc 'utf-8 'utf-8)
         (process-put proc 'fstar-subp-source-buffer (current-buffer))
         (setq fstar-subp--process proc)
+	(setq fstar--parent-buffer nil) ; No longer depend on parent
         (setq fstar-subp--prover-args args)
         (setq fstar-subp--continuations (make-hash-table :test 'equal))
         (when (fstar--has-feature 'json-subp)

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -2347,7 +2347,7 @@ FEATURE, if specified."
   (when feature
     (fstar--has-feature feature error-fn)))
 
-(defun fstar-subp--ensure-available-free-anywhere (error-fn)
+(defun fstar-subp--find-any-free-process (error-fn)
   "Return a free fstar process if available in some buffer.
 Raise an error with ERROR-FN if a free F* process isn't available anywhere."
   (let ((result nil))
@@ -4218,7 +4218,7 @@ DISPLAY-ACTION indicates how: nil means in the current window;
   "Jump to definition of identifier at POS, if any.
 DISP should be nil (display in same window) or
 `window' (display in a side window)."
-  (let ((buf (fstar-subp--ensure-available-free-anywhere #'user-error))
+  (let ((buf (fstar-subp--find-any-free-process #'user-error))
 	(query (fstar-subp--positional-lookup-query pos '(defined-at))))
     (with-current-buffer buf
       (fstar-subp--query query

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -4201,14 +4201,13 @@ the search buffer."
 
 ;;; ;; ;; Jump to definition
 
-(defun fstar--jump-to-definition-continuation (display-action buf info)
+(defun fstar--jump-to-definition-continuation (display-action info)
   "Jump to position in INFO.
 DISPLAY-ACTION indicates how: nil means in the current window;
 `window' means in a side window."
   (-if-let* ((def-loc (and (fstar-lookup-result-p info)
 			   (fstar-lookup-result-def-loc info))))
-      (with-current-buffer buf
-	(fstar--navigate-to def-loc display-action))
+      (fstar--navigate-to def-loc display-action)
     (message "No definition found")))
 
 (defun fstar-jump-to-definition-1 (pos disp)
@@ -4216,13 +4215,12 @@ DISPLAY-ACTION indicates how: nil means in the current window;
 DISP should be nil (display in same window) or
 `window' (display in a side window)."
   (let ((buf (fstar-subp--ensure-available-free-anywhere #'user-error))
-	(cur-buf (current-buffer))
 	(query (fstar-subp--positional-lookup-query pos '(defined-at))))
     (with-current-buffer buf
       (fstar-subp--query query
 			 (fstar-subp--lookup-wrapper (point) (apply-partially
 							      #'fstar--jump-to-definition-continuation
-							      disp cur-buf))))))
+							      disp))))))
 
 (defun fstar-jump-to-definition ()
   "Jump to definition of identifier at point, if any."

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -5247,7 +5247,6 @@ Could it be a typo in `fstar-subp-prover-args' or \
         (set-process-coding-system proc 'utf-8 'utf-8)
         (process-put proc 'fstar-subp-source-buffer (current-buffer))
         (setq fstar-subp--process proc)
-	(setq fstar--parent-buffer nil) ; No longer depend on parent
         (setq fstar-subp--prover-args args)
         (setq fstar-subp--continuations (make-hash-table :test 'equal))
         (when (fstar--has-feature 'json-subp)

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -4204,11 +4204,12 @@ DISPLAY-ACTION indicates how: nil means in the current window;
   "Jump to definition of identifier at POS, if any.
 DISP should be nil (display in same window) or
 `window' (display in a side window)."
-  (fstar-subp--ensure-available #'user-error 'lookup)
-  (fstar-subp--query (fstar-subp--positional-lookup-query pos
-                  '(defined-at))
-                (fstar-subp--lookup-wrapper pos
-                  (apply-partially #'fstar--jump-to-definition-continuation disp))))
+  (let ((buf (fstar-subp--ensure-available-free-anywhere #'user-error)))
+    (with-current-buffer buf
+      (fstar-subp--query (fstar-subp--positional-lookup-query pos '(defined-at))
+			 (fstar-subp--lookup-wrapper pos (apply-partially
+							  #'fstar--jump-to-definition-continuation
+							  disp))))))
 
 (defun fstar-jump-to-definition ()
   "Jump to definition of identifier at point, if any."

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -4213,9 +4213,9 @@ DISP should be nil (display in same window) or
   (let ((buf (fstar-subp--ensure-available-free-anywhere #'user-error)))
     (with-current-buffer buf
       (fstar-subp--query (fstar-subp--positional-lookup-query pos '(defined-at))
-			 (fstar-subp--lookup-wrapper pos (apply-partially
-							  #'fstar--jump-to-definition-continuation
-							  disp))))))
+    			 (fstar-subp--lookup-wrapper pos (apply-partially
+    							  #'fstar--jump-to-definition-continuation
+    							  disp))))))
 
 (defun fstar-jump-to-definition ()
   "Jump to definition of identifier at point, if any."


### PR DESCRIPTION
Some preliminary work towards being able to jump to a definition even when we don't have F* loaded up in the current buffer. Will update this PR as I make progress. The reason I am opening a WIP PR though is because I would appreciate feedback on feasibility (or if a better/easier approach exists for this already).

The way this works is by first looking for another buffer where there is an available free F* process (this is likely to be the case if you are jumping many layers deep- the first process will remain free). If not, then it just complains. If it can find one, then by using that buffer's F* process, it finds the place to jump to, and then performs the jump.

## TODOs before merging:
- [x] Find the first free F* process
  - [x] Suggestion by @cpitclaudel : Use parent buffer if possible first (if current buffer is not possible), and fall back on search only if parent is unavailable.
- [x] Give current buffer highest priority
- [x] Improve this and fallback on old behavior if unable to find a free F* process
- [x] Pass along process details to the jump/continuation, so that we can actually make the jump
- [x] Make sure that the current buffers/windows are changed/updated by a jump
- [x] Think about what if some module is accessible by one free F* process but not by another?
  - In this case we just ignore doing stuff. Not sure how else to handle it better.