### PR TITLE
Prevent teardown if in an indirect buffer

### DIFF
--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -5511,7 +5511,8 @@ its `find-image' forms."
 
 (defun fstar-teardown ()
   "Run all teardown functions."
-  (fstar-run-module-functions 'teardown))
+  (unless (buffer-base-buffer)
+    (fstar-run-module-functions 'teardown)))
 
 (defun fstar-setup-hooks ()
   "Setup hooks required by F*-mode."


### PR DESCRIPTION
When we are in an indirect buffer, killing the indirect buffer causes the base buffer to also undergo a teardown. This commit makes sure to check whether we are actually in the right buffer, before initiating a teardown, thereby preventing spurious teardowns. Only killing the base buffer performs a teardown now with this PR.