### PR TITLE
Adding restart-solver to get syntax highlighting in emacs

### DIFF
--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -867,7 +867,7 @@ allows composition in code comments."
   (format "^[[:space:]]*\\(%s\\)\\_>" (regexp-opt fstar-syntax-fsdoc-keywords)))
 
 (defconst fstar-syntax-preprocessor
-  '("#set-options" "#reset-options" "#push-options" "#pop-options" "#light"))
+  '("#set-options" "#reset-options" "#push-options" "#pop-options" "#restart-solver" "#light"))
 
 (defconst fstar-syntax-qualifiers
   '("new" "abstract" "logic" "assume" "visible"


### PR DESCRIPTION
Hi @cpitclaudel, a simple change but making a PR to make sure that there are no unintended consequences. @mtzguido added a new pragma `#reset-solver`, this PR is just to get syntax highlighting for it.