### PR TITLE
Do not clean up types via a regex

### DIFF
--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -1194,10 +1194,6 @@ leads to the binder's start."
       (flycheck-mode -1)
       (fstar-mode))))
 
-(defun fstar--cleanup-type (type)
-  "Clean up TYPE."
-  (replace-regexp-in-string "\\(?:uu___[0-9]*:\\|[@#][0-9]+\\_>\\)" "" type t t))
-
 (defun fstar--unparens (str)
   "Remove parentheses surrounding STR, if any."
   (if (and str
@@ -1218,7 +1214,7 @@ leads to the binder's start."
   (fstar--init-scratchpad)
   (with-current-buffer fstar--scratchpad
     (erase-buffer)
-    (insert (fstar--cleanup-type str))
+    (insert str)
     (fstar--font-lock-ensure)
     (buffer-string)))
 


### PR DESCRIPTION
This was meant to reduce the clutter on printed terms, but our pretty
printer is now smarter about it.

See also FStarLang/FStar#1869