### PR TITLE
Fix fstar-syntax-block-start-re to consider attributes

### DIFF
--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -890,7 +890,7 @@ allows composition in code comments."
   "Regexp matching block headers.")
 
 (defconst fstar-syntax-block-start-re
-  (format "^\\(?:%s[ \n]\\)*%s "
+  (format "^\\(?:%s[ \n]\\)*\\(\\[@\\|%s \\)"
           (regexp-opt fstar-syntax-qualifiers)
           (regexp-opt (append (remove "and" fstar-syntax-headers)
                               fstar-syntax-preprocessor)))


### PR DESCRIPTION
Hey Clément, I noticed that attributes were confusing the detection of the next block. I have this patch that seems to fix it, but it could sure use your expert eye to check I'm not doing something stupid :).

Thanks!


------


Before this change, running C-c C-n on a fragment like this
```fstar
  let _ = 0

  [@] let _ = 2

  [@] let _ = 2

  [@] let _ = 2
```
Would blast through all of them instead of going one at a time.