### PR TITLE
Fixes to syntax headers

### DIFF
--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -866,7 +866,7 @@ allows composition in code comments."
 (defconst fstar-syntax-headers
   '("open" "module" "include" "friend"
     "let" "let rec" "val" "and"
-    "exception" "effect" "new_effect" "sub_effect" "new_effect_for_free"
+    "exception" "effect" "new_effect" "sub_effect" "new_effect_for_free" "layered_effect"
     "kind" "type" "class" "instance"))
 
 (defconst fstar-syntax-fsdoc-keywords

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -865,7 +865,7 @@ allows composition in code comments."
 
 (defconst fstar-syntax-headers
   '("open" "module" "include" "friend"
-    "let" "let rec" "val" "and"
+    "let" "let rec" "val" "and" "assume"
     "exception" "effect" "new_effect" "sub_effect" "new_effect_for_free" "layered_effect"
     "kind" "type" "class" "instance"))
 


### PR DESCRIPTION
Related to the very previous PR :)

We now have `layered_effect` as a header. Also, `assume` can be a header (instead of a qualifier) for top-level SMT assumes.