### PR TITLE
README.md: http->https for MELPA URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ F*-mode requires Emacs 24.3 or newer, and is distributed through [MELPA](https:/
 
     ```elisp
     (require 'package)
-    (add-to-list 'package-archives '("melpa" . "http://melpa.org/packages/") t)
+    (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
     (package-initialize)
     ```
 


### PR DESCRIPTION
The MELPA official website specifies the URL with https: https://melpa.org/#/getting-started

I suspect that using http may lead to some errors when fetching packages.