### PR TITLE
(RFC) Use an 'urgency' flag to decide whether to pop-up the goals buffer

### DIFF
--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -2777,10 +2777,9 @@ potential errors.")
   "Concatenate ISSUE's level and message."
   (format "(%s%s) %s"
           (capitalize (symbol-name (fstar-issue-level issue)))
-          (let ((numopt (fstar-issue-number issue)))
-            (if numopt
-                (concat " " (number-to-string numopt))
-                ""))
+          (-if-let* ((num (fstar-issue-number issue)))
+             (concat " " (number-to-string num))
+             "")
           (fstar-issue-message issue)))
 
 (defconst fstar-subp-issue-location-regexp


### PR DESCRIPTION
Hi Clément,

with @R1kM and others we were finding the fact that the goals buffers always opens up on a tactics error a bit annoying (especially when many buffers are open). So I came up with this patch to decide whether to display it or not. The idea is that F* provides and "urgency" level for each proofstate (currently just 0 or 1), and emacs will only pop-up the buffer when it is 1 (but will always log the error in the buffer). The urgency is 1 by default to not affect the old behavior.

Does this look sensible to you? I would imagine there's probably better ways to do it :-)

(F* `master` doesn't pass the urgency field yet, `guido_tactics` does).