### PR TITLE
advance-to-point advance to the end of the current block

### DIFF
--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -3485,9 +3485,9 @@ into blocks; process it as one large block instead."
      ((fstar-subp--in-tracked-region-p)
       (fstar-subp-retract-until (point)))
      ((consp arg)
-      (fstar-subp-enqueue-until (point)))
+      (fstar-subp-enqueue-until (save-excursion (fstar-subp-next-block-end) (point))))
      (t
-      (fstar-subp-advance-until (point))))))
+      (fstar-subp-advance-until (save-excursion (fstar-subp-next-block-end) (point)))))))
 
 (defun fstar-subp-advance-or-retract-to-point-lax (&optional arg)
   "Like `fstar-subp-advance-or-retract-to-point' with ARG, in lax mode."


### PR DESCRIPTION
This pull request modifies the behavior of `fstar-subp-advance-or-retract-to-point` such that it will advance to the end of the current block.

Previously, if the cursor is in the middle of a block, for example,
```
let foo (_: unit) = ()
             ^
```
Pressing `C-c RET` will pass `let foo(` to the sub-process, and reports an error. The updated function will pass the entirety of `let foo ...` to the process and succeed. This is helpful when I'm still trying to figure out the function body (especially if it spans multiple line), since I won't need to move my cursor (which I can use `M-n`) and back (which is more difficult).

I'm not a fstar power user and in all my use cases, I'm always advancing the proof checker on a block granularity. Maybe there is indeed a demand for sub-block advancement (maybe at tactic level, such as in Coq). If that's the case, I can create a separate function for this altered behavior and register a different key for it.