### PR TITLE
Fix deprecated functions in sphinx extension

### DIFF
--- a/etc/fslit/sphinx4fstar.py
+++ b/etc/fslit/sphinx4fstar.py
@@ -68,14 +68,14 @@ def add_html_assets(app):
     if app.builder.name == "html":
         app.config.html_static_path.append(docutils4fstar.ASSETS_PATH)
 
-        app.add_javascript("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.36.0/codemirror.min.js")
-        app.add_stylesheet("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.36.0/codemirror.min.css")
+        app.add_js_file("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.36.0/codemirror.min.js")
+        app.add_css_file("https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.36.0/codemirror.min.css")
 
-        app.add_javascript("fstar.cm.js")
-        app.add_stylesheet("cm.tango.css")
+        app.add_js_file("fstar.cm.js")
+        app.add_css_file("cm.tango.css")
 
-        app.add_javascript("fslit.js")
-        app.add_stylesheet("fslit.css")
+        app.add_js_file("fslit.js")
+        app.add_css_file("fslit.css")
 
 def setup(app):
     """Register the F* domain"""


### PR DESCRIPTION
The two functions add_javascript and add_stylesheet, which were used in Sphinx's extension, have been deprecated from Sphinx version 1.8.
I replaced them with their new names.