### PR TITLE
init-compatibility-layer: fix F* version check

### DIFF
--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -738,10 +738,11 @@ enable all experimental features."
         (message "F*: Can't parse version number from %S; assuming %s (\
 don't worry about this if you're running an F#-based F* build)."
                  version-string fstar-assumed-vernum))
-      (setq fstar--vernum fstar-assumed-vernum)))
+      (setq fstar--vernum "unknown")))
+  (let ((vernum (if (equal fstar--vernum "unknown") fstar-assumed-vernum fstar--vernum)))
     (pcase-dolist (`(,feature . ,min-version) fstar--features-min-version-alist)
-      (when (version<= min-version fstar--vernum)
-        (push feature fstar--features))))
+      (when (version<= min-version vernum)
+        (push feature fstar--features)))))
 
 (defun fstar--has-feature (feature &optional error-fn)
   "Check if FEATURE is available in the current F*.

--- a/fstar-mode.el
+++ b/fstar-mode.el
@@ -732,17 +732,16 @@ enable all experimental features."
 (defun fstar--init-compatibility-layer (executable)
   "Adjust compatibility settings based on EXECUTABLE's version number."
   (let* ((version-string (fstar--query-vernum executable)))
-    (if (string-match "^F\\* \\([- .[:alnum:]]+\\)" version-string)
+    (if (string-match "^F\\* \\([0-9][- .[:alnum:]]*\\)" version-string)
         (setq fstar--vernum (match-string 1 version-string))
       (let ((print-escape-newlines t))
         (message "F*: Can't parse version number from %S; assuming %s (\
 don't worry about this if you're running an F#-based F* build)."
                  version-string fstar-assumed-vernum))
-      (setq fstar--vernum "unknown")))
-  (let ((vernum (if (equal fstar--vernum "unknown") fstar-assumed-vernum fstar--vernum)))
+      (setq fstar--vernum fstar-assumed-vernum)))
     (pcase-dolist (`(,feature . ,min-version) fstar--features-min-version-alist)
-      (when (version<= min-version vernum)
-        (push feature fstar--features)))))
+      (when (version<= min-version fstar--vernum)
+        (push feature fstar--features))))
 
 (defun fstar--has-feature (feature &optional error-fn)
   "Check if FEATURE is available in the current F*.


### PR DESCRIPTION
A valid F* version number must start with a number; on recent emacsen (e.g. 29.4), `version<=` (in fact, `version-to-list`) will fail if not. So, we fix the regexp accordingly.

~In the case the F* version string does not parse properly, we also assume the version number globally, instead of setting it to "unknown". This way, we guarantee that `fstar--vernum` will always be a valid version number.~